### PR TITLE
tokio-util 0.3 upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,7 @@ dependencies = [
  "log",
  "slab",
  "tokio",
- "tokio-util 0.3.1",
+ "tokio-util",
 ]
 
 [[package]]
@@ -359,7 +359,7 @@ dependencies = [
  "futures",
  "hyper",
  "tokio",
- "tokio-util 0.2.0",
+ "tokio-util",
  "websocket-codec",
 ]
 
@@ -938,20 +938,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
@@ -1070,7 +1056,7 @@ dependencies = [
  "quickcheck_macros",
  "rand",
  "sha1",
- "tokio-util 0.2.0",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1087,7 +1073,7 @@ dependencies = [
  "tokio",
  "tokio-openssl",
  "tokio-tls",
- "tokio-util 0.2.0",
+ "tokio-util",
  "url",
  "websocket-codec",
 ]

--- a/hyper-websocket-lite/Cargo.toml
+++ b/hyper-websocket-lite/Cargo.toml
@@ -23,4 +23,4 @@ futures = "0.3"
 hyper = "0.13"
 websocket-codec = { version = "0.3.3", path = "../websocket-codec" }
 tokio = { version = "0.2", features=["macros"] }
-tokio-util = { version = "0.2", features=["codec"] }
+tokio-util = { version = "0.3", features=["codec"] }

--- a/websocket-codec/Cargo.toml
+++ b/websocket-codec/Cargo.toml
@@ -17,7 +17,7 @@ bytes = "0.5"
 httparse = "1"
 rand = "0.7"
 sha1 = "0.6"
-tokio-util = { version="0.2", features=["codec"] }
+tokio-util = { version="0.3", features=["codec"] }
 
 [dev-dependencies]
 assert-allocations = { path="../assert-allocations" }

--- a/websocket-codec/src/message.rs
+++ b/websocket-codec/src/message.rs
@@ -221,8 +221,7 @@ impl Decoder for MessageCodec {
     }
 }
 
-impl Encoder for MessageCodec {
-    type Item = Message;
+impl Encoder<Message> for MessageCodec {
     type Error = Error;
 
     fn encode(&mut self, item: Message, dst: &mut BytesMut) -> Result<()> {

--- a/websocket-codec/src/upgrade.rs
+++ b/websocket-codec/src/upgrade.rs
@@ -134,8 +134,7 @@ impl Decoder for UpgradeCodec {
     }
 }
 
-impl Encoder for UpgradeCodec {
-    type Item = ();
+impl Encoder<()> for UpgradeCodec {
     type Error = Error;
 
     fn encode(&mut self, _item: (), _dst: &mut BytesMut) -> Result<()> {

--- a/websocket-lite/Cargo.toml
+++ b/websocket-lite/Cargo.toml
@@ -33,7 +33,7 @@ futures = "0.3"
 native-tls = { version = "0.2", optional = true }
 openssl = { version = "0.10", optional = true }
 rand = "0.7"
-tokio-util = {version= "0.2", features=["codec"]}
+tokio-util = {version= "0.3", features=["codec"]}
 tokio-openssl = { version = "0.4.0-alpha.6", optional = true }
 tokio-tls = { version = "0.3", optional = true }
 tokio = {version="0.2", features=["tcp", "io-util"]}

--- a/websocket-lite/src/client.rs
+++ b/websocket-lite/src/client.rs
@@ -19,11 +19,11 @@ use crate::ssl;
 use crate::sync;
 use crate::{AsyncClient, AsyncNetworkStream, Client, MessageCodec, NetworkStream, Result};
 
-fn replace_codec<T, C1, C2>(framed: Framed<T, C1>, codec: C2) -> Framed<T, C2>
+fn replace_codec<T, C1, C2, Item1, Item2>(framed: Framed<T, C1>, codec: C2) -> Framed<T, C2>
 where
     T: AsyncRead + AsyncWrite,
-    C1: Encoder + Decoder,
-    C2: Encoder + Decoder,
+    C1: Encoder<Item1> + Decoder,
+    C2: Encoder<Item2> + Decoder,
 {
     // TODO improve this? https://github.com/tokio-rs/tokio/issues/717
     let parts1 = framed.into_parts();

--- a/websocket-lite/src/sync.rs
+++ b/websocket-lite/src/sync.rs
@@ -31,8 +31,11 @@ impl<S, C> Framed<S, C> {
     }
 }
 
-impl<S: Write, C: Encoder> Framed<S, C> {
-    pub fn send(&mut self, item: C::Item) -> Result<(), C::Error> {
+impl<S: Write, C> Framed<S, C> {
+    pub fn send<Item>(&mut self, item: Item) -> Result<(), C::Error>
+    where
+        C: Encoder<Item>,
+    {
         self.write_buf.truncate(0);
         self.codec.encode(item, &mut self.write_buf)?;
         self.stream.write_all(&self.write_buf)?;


### PR DESCRIPTION
`tokio-util 0.3` remove the associated type of the `Encoder` trait. This PR updates the crate to use this new API

improves on #58 