### PR TITLE
update to tokio 0.3 and bytes 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
  "bytes 0.6.0",
  "libfuzzer-sys",
  "tokio-util 0.5.0",
- "websocket-codec",
+ "websocket-codec 0.4.0",
 ]
 
 [[package]]
@@ -529,9 +529,9 @@ version = "0.3.5"
 dependencies = [
  "futures",
  "hyper",
- "tokio 0.3.2",
- "tokio-util 0.5.0",
- "websocket-codec",
+ "tokio 0.2.22",
+ "tokio-util 0.3.1",
+ "websocket-codec 0.3.5",
 ]
 
 [[package]]
@@ -1336,6 +1336,7 @@ dependencies = [
  "mio 0.6.21",
  "pin-project-lite",
  "slab",
+ "tokio-macros 0.2.5",
 ]
 
 [[package]]
@@ -1351,8 +1352,18 @@ dependencies = [
  "memchr",
  "mio 0.7.5",
  "pin-project-lite",
- "slab",
- "tokio-macros",
+ "tokio-macros 0.3.1",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1606,6 +1617,21 @@ dependencies = [
 [[package]]
 name = "websocket-codec"
 version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33eea455ea3a328dea4d3c2a30b3c0e1a6475e8b1bc9a1defe2365a3e7128756"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes 0.5.6",
+ "httparse",
+ "rand",
+ "sha1",
+ "tokio-util 0.3.1",
+]
+
+[[package]]
+name = "websocket-codec"
+version = "0.4.0"
 dependencies = [
  "assert-allocations",
  "base64",
@@ -1624,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "websocket-lite"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "base64",
  "bytes 0.6.0",
@@ -1638,7 +1664,7 @@ dependencies = [
  "tokio-openssl",
  "tokio-util 0.5.0",
  "url",
- "websocket-codec",
+ "websocket-codec 0.4.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,7 +1351,9 @@ dependencies = [
  "libc",
  "memchr",
  "mio 0.7.5",
+ "num_cpus",
  "pin-project-lite",
+ "slab",
  "tokio-macros 0.3.1",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -36,7 +36,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -86,6 +86,12 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "bytes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
 
 [[package]]
 name = "c2-chacha"
@@ -406,9 +412,9 @@ dependencies = [
 name = "fuzz"
 version = "0.0.0"
 dependencies = [
- "bytes",
+ "bytes 0.6.0",
  "libfuzzer-sys",
- "tokio-util",
+ "tokio-util 0.5.0",
  "websocket-codec",
 ]
 
@@ -429,7 +435,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "377038bf3c89d18d6ca1431e7a5027194fbd724ca10592b9487ede5e8e144f42"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -438,8 +444,8 @@ dependencies = [
  "indexmap",
  "log",
  "slab",
- "tokio",
- "tokio-util",
+ "tokio 0.2.22",
+ "tokio-util 0.3.1",
 ]
 
 [[package]]
@@ -472,7 +478,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b708cc7f06493459026f53b9a61a7a121a5d1ec6238dee58ea4941132b30156b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
@@ -483,7 +489,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "http",
 ]
 
@@ -499,7 +505,7 @@ version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e68a8dd9716185d9e64ea473ea6ef63529252e3e27623295a0378a19665d5eb"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -511,7 +517,7 @@ dependencies = [
  "pin-project",
  "socket2",
  "time",
- "tokio",
+ "tokio 0.2.22",
  "tower-service",
  "tracing",
  "want",
@@ -523,8 +529,8 @@ version = "0.3.5"
 dependencies = [
  "futures",
  "hyper",
- "tokio",
- "tokio-util",
+ "tokio 0.3.2",
+ "tokio-util 0.5.0",
  "websocket-codec",
 ]
 
@@ -599,9 +605,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.66"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -662,10 +668,23 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow",
+ "miow 0.2.1",
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8962c171f57fcfffa53f4df1bb15ec4c8cf26a7569459c9ceb62d94aab0d9584"
+dependencies = [
+ "libc",
+ "log",
+ "miow 0.3.5",
+ "ntapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -678,6 +697,16 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+dependencies = [
+ "socket2",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -706,7 +735,16 @@ checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 dependencies = [
  "cfg-if",
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1024,7 +1062,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1058,7 +1096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507a9e6e8ffe0a4e0ebb9a10293e62fdf7657c06f1b8bb07a8fcf697d2abf295"
 dependencies = [
  "lazy_static",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1169,7 +1207,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1241,7 +1279,7 @@ dependencies = [
  "rand",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1270,7 +1308,7 @@ checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 dependencies = [
  "libc",
  "redox_syscall",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1289,13 +1327,29 @@ version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
  "lazy_static",
  "memchr",
- "mio",
+ "mio 0.6.21",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "tokio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71f1b20504fd0aa9dab3ae17e8c4dd9431e5e08fd6921689f9745a4004883a17"
+dependencies = [
+ "bytes 0.6.0",
+ "futures-core",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "mio 0.7.5",
  "pin-project-lite",
  "slab",
  "tokio-macros",
@@ -1303,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.4"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4b1e7ed7d5d4c2af3d999904b0eebe76544897cdbfb2b9684bed2174ab20f7c"
+checksum = "21d30fdbb5dc2d8f91049691aa1a9d4d4ae422a21c334ce8936e5886d30c5c45"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1313,23 +1367,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-openssl"
-version = "0.4.0"
+name = "tokio-native-tls"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c4b08c5f4208e699ede3df2520aca2e82401b2de33f45e96696a074480be594"
+checksum = "501c8252b73bd01379aaae1521523c2629ff1bc6ea46c29e0baff515cee60f1b"
 dependencies = [
- "openssl",
- "tokio",
+ "native-tls",
+ "tokio 0.3.2",
 ]
 
 [[package]]
-name = "tokio-tls"
-version = "0.3.1"
+name = "tokio-openssl"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
+checksum = "d01e5cc2d3a154fa310982d0affaec8140d6476805422265b2f648eb813f937f"
 dependencies = [
- "native-tls",
- "tokio",
+ "openssl",
+ "openssl-sys",
+ "tokio 0.3.2",
 ]
 
 [[package]]
@@ -1338,12 +1393,26 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
  "pin-project-lite",
- "tokio",
+ "tokio 0.2.22",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73af76301319bcacf00d26d3c75534ef248dcad7ceaf36d93ec902453c3b1706"
+dependencies = [
+ "bytes 0.6.0",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio 0.3.2",
 ]
 
 [[package]]
@@ -1450,7 +1519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 dependencies = [
  "same-file",
- "winapi 0.3.8",
+ "winapi 0.3.9",
  "winapi-util",
 ]
 
@@ -1541,7 +1610,7 @@ dependencies = [
  "assert-allocations",
  "base64",
  "byteorder",
- "bytes",
+ "bytes 0.6.0",
  "criterion",
  "httparse",
  "quickcheck",
@@ -1550,7 +1619,7 @@ dependencies = [
  "sha1",
  "static_assertions",
  "structopt",
- "tokio-util",
+ "tokio-util 0.5.0",
 ]
 
 [[package]]
@@ -1558,16 +1627,16 @@ name = "websocket-lite"
 version = "0.3.5"
 dependencies = [
  "base64",
- "bytes",
+ "bytes 0.6.0",
  "futures",
  "native-tls",
  "openssl",
  "rand",
  "structopt",
- "tokio",
+ "tokio 0.3.2",
+ "tokio-native-tls",
  "tokio-openssl",
- "tokio-tls",
- "tokio-util",
+ "tokio-util 0.5.0",
  "url",
  "websocket-codec",
 ]
@@ -1580,9 +1649,9 @@ checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -1606,7 +1675,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-bytes = "0.5"
+bytes = "0.6"
 libfuzzer-sys = "0.3"
-tokio-util = { version="0.3", features=["codec"] }
+tokio-util = { version="0.5", features=["codec"] }
 websocket-codec = { path = "../websocket-codec" }
 
 [[bin]]

--- a/hyper-websocket-lite/Cargo.toml
+++ b/hyper-websocket-lite/Cargo.toml
@@ -10,6 +10,6 @@ edition = "2018"
 [dependencies]
 futures = "0.3"
 hyper = "0.13"
-websocket-codec = { version = "0.3.5", path = "../websocket-codec" }
-tokio = { version = "0.3", features=["macros", "rt"] }
-tokio-util = { version = "0.5", features=["codec"] }
+websocket-codec = { version = "0.3.5" }
+tokio = { version = "0.2", features=["macros"] }
+tokio-util = { version = "0.3", features=["codec"] }

--- a/hyper-websocket-lite/Cargo.toml
+++ b/hyper-websocket-lite/Cargo.toml
@@ -11,5 +11,5 @@ edition = "2018"
 futures = "0.3"
 hyper = "0.13"
 websocket-codec = { version = "0.3.5", path = "../websocket-codec" }
-tokio = { version = "0.2", features=["macros"] }
-tokio-util = { version = "0.3", features=["codec"] }
+tokio = { version = "0.3", features=["macros", "rt"] }
+tokio-util = { version = "0.5", features=["codec"] }

--- a/websocket-codec/Cargo.toml
+++ b/websocket-codec/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "websocket-codec"
 description = "A Tokio codec for the websocket protocol"
-version = "0.3.5"
+version = "0.4.0"
 authors = ["Tim Robinson <tim.g.robinson@gmail.com>"]
 repository = "https://github.com/1tgr/rust-websocket-lite"
 license = "MIT"

--- a/websocket-codec/Cargo.toml
+++ b/websocket-codec/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 [dependencies]
 base64 = "0.12"
 byteorder = "1"
-bytes = "0.5"
+bytes = "0.6"
 httparse = "1"
 rand = "0.7"
 sha1 = "0.6"
-tokio-util = { version="0.3", features=["codec"] }
+tokio-util = { version="0.5", features=["codec"] }
 
 [dev-dependencies]
 assert-allocations = { path="../assert-allocations" }

--- a/websocket-codec/src/frame.rs
+++ b/websocket-codec/src/frame.rs
@@ -301,7 +301,6 @@ impl Decoder for FrameHeaderCodec {
 
 impl Encoder<FrameHeader> for FrameHeaderCodec {
     type Error = Error;
-
     fn encode(&mut self, item: FrameHeader, dst: &mut BytesMut) -> Result<()> {
         self.encode(&item, dst)
     }

--- a/websocket-codec/src/frame.rs
+++ b/websocket-codec/src/frame.rs
@@ -301,6 +301,7 @@ impl Decoder for FrameHeaderCodec {
 
 impl Encoder<FrameHeader> for FrameHeaderCodec {
     type Error = Error;
+
     fn encode(&mut self, item: FrameHeader, dst: &mut BytesMut) -> Result<()> {
         self.encode(&item, dst)
     }

--- a/websocket-lite/Cargo.toml
+++ b/websocket-lite/Cargo.toml
@@ -23,7 +23,7 @@ websocket-codec = { version = "0.4", path = "../websocket-codec" }
 
 [dev-dependencies]
 structopt = "0.3"
-tokio = { version = "0.3", features=["macros", "time", "io-std"] }
+tokio = { version = "0.3", features=["macros", "time", "io-std", "rt-multi-thread"] }
 
 [features]
 default = ["ssl-native-tls"]

--- a/websocket-lite/Cargo.toml
+++ b/websocket-lite/Cargo.toml
@@ -9,26 +9,26 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.12"
-bytes = "0.5"
+bytes = "0.6"
 futures = "0.3"
 native-tls = { version = "0.2", optional = true }
 openssl = { version = "0.10", optional = true }
 rand = "0.7"
-tokio-util = {version= "0.3", features=["codec"]}
-tokio-openssl = { version = "0.4.0-alpha.6", optional = true }
-tokio-tls = { version = "0.3", optional = true }
-tokio = {version="0.2", features=["tcp", "io-util"]}
+tokio-util = {version= "0.5", features=["codec"]}
+tokio-openssl = { version = "0.5", optional = true }
+tokio-native-tls = { version = "0.2", optional = true }
+tokio = {version="0.3", features=["net", "io-util"]}
 url = "2"
 websocket-codec = { version = "0.3.5", path = "../websocket-codec" }
 
 [dev-dependencies]
 structopt = "0.3"
-tokio = { version = "0.2", features=["macros", "time", "io-std"] }
+tokio = { version = "0.3", features=["macros", "time", "io-std"] }
 
 [features]
 default = ["ssl-native-tls"]
 nightly = []
-ssl-native-tls = ["native-tls", "tokio-tls"]
+ssl-native-tls = ["native-tls", "tokio-native-tls"]
 ssl-openssl = ["openssl", "tokio-openssl"]
 
 ## Uncomment to enable the SSLKEYLOGFILE environment variable when the ssl-openssl feature is used

--- a/websocket-lite/Cargo.toml
+++ b/websocket-lite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "websocket-lite"
 description = "A fast, low-overhead WebSocket client"
-version = "0.3.5"
+version = "0.4.0"
 authors = ["Tim Robinson <tim.g.robinson@gmail.com>"]
 repository = "https://github.com/1tgr/rust-websocket-lite"
 license = "MIT"
@@ -19,7 +19,7 @@ tokio-openssl = { version = "0.5", optional = true }
 tokio-native-tls = { version = "0.2", optional = true }
 tokio = {version="0.3", features=["net", "io-util"]}
 url = "2"
-websocket-codec = { version = "0.3.5", path = "../websocket-codec" }
+websocket-codec = { version = "0.4", path = "../websocket-codec" }
 
 [dev-dependencies]
 structopt = "0.3"

--- a/websocket-lite/examples/wsdump.rs
+++ b/websocket-lite/examples/wsdump.rs
@@ -43,8 +43,8 @@ async fn main() -> Result<()> {
             sink.send(message).await?;
         }
 
-        time::delay_for(eof_wait).await;
-        Ok(()) as Result<()>
+        time::sleep(eof_wait).await;
+        Ok(()) 
     };
 
     let recv_loop = async {

--- a/websocket-lite/src/ssl.rs
+++ b/websocket-lite/src/ssl.rs
@@ -14,10 +14,10 @@ mod inner {
     pub async fn async_wrap<S: AsyncRead + AsyncWrite + Unpin>(
         domain: String,
         stream: S,
-    ) -> Result<::tokio_tls::TlsStream<S>> {
+    ) -> Result<tokio_native_tls::TlsStream<S>> {
         let builder = TlsConnector::builder();
         let cx = builder.build()?;
-        Ok(tokio_tls::TlsConnector::from(cx).connect(&domain, stream).await?)
+        Ok(tokio_native_tls::TlsConnector::from(cx).connect(&domain, stream).await?)
     }
 
     pub fn wrap<S: Read + Write + Debug + 'static>(domain: &str, stream: S) -> Result<::native_tls::TlsStream<S>> {

--- a/websocket-lite/src/sync.rs
+++ b/websocket-lite/src/sync.rs
@@ -1,5 +1,4 @@
 use std::io::{Read, Write};
-use std::mem::MaybeUninit;
 
 use bytes::{BufMut, BytesMut};
 use tokio_util::codec::{Decoder, Encoder};
@@ -59,12 +58,10 @@ impl<S: Read, C: Decoder> Framed<S, C> {
             let buf = self.read_buf.bytes_mut();
 
             let buf = unsafe {
-                for x in buf.iter_mut() {
-                    *x.as_mut_ptr() = 0;
-                    x.assume_init();
+                for i in 0..buf.len() {
+                    buf.write_byte(i, 0);
                 }
-
-                &mut *(buf as *mut [MaybeUninit<u8>] as *mut [u8])
+                std::slice::from_raw_parts_mut(buf.as_mut_ptr(), buf.len())
             };
 
             let n = self.stream.read(buf)?;


### PR DESCRIPTION
## Changes

This PR updates all dependencies over `tokio v0.3` and `bytes v0.6`

## Hyper 0.14

The full update would currently be failing since hyper hasn't updated their API to `tokio v0.3`. I believe it is better not to modify  `hyper-websocket-lite` in this PR, this should be handled when [changes](https://github.com/hyperium/hyper/pull/2317) have been merged in hyper.

closes #109 #113 #106 