### PR TITLE
Enable buffering multiple messages before flush

### DIFF
--- a/websocket-codec/src/frame.rs
+++ b/websocket-codec/src/frame.rs
@@ -264,16 +264,15 @@ impl FrameHeader {
             DataLength::Large(n) => n as usize,
         };
 
+        let initial_len = dst.len();
         let header_len = self.header_len();
         dst.reserve(header_len + data_len);
 
-        if header_len > dst.len() {
-            unsafe {
-                dst.set_len(header_len);
-            }
+        unsafe {
+            dst.set_len(initial_len + header_len);
         }
 
-        let dst_slice = &mut dst[0..header_len];
+        let dst_slice = &mut dst[initial_len..(initial_len + header_len)];
         self.write_to_slice(dst_slice);
     }
 }

--- a/websocket-codec/src/message.rs
+++ b/websocket-codec/src/message.rs
@@ -472,7 +472,7 @@ mod tests {
     fn roundtrips_multiple_messages() {
         // According to https://docs.rs/tokio-util/0.7.3/tokio_util/codec/index.html#the-encoder-trait
         // the buffer given to the Encoder may already contain data.
-        // Therefore, we check whether writing two messages into the same buffer roundtrips correctly.        
+        // Therefore, we check whether writing two messages into the same buffer roundtrips correctly.
         let mut buf = BytesMut::new();
         let mut codec = MessageCodec::server();
         codec.encode(Message::text("A"), &mut buf).unwrap();

--- a/websocket-codec/src/message.rs
+++ b/websocket-codec/src/message.rs
@@ -473,8 +473,6 @@ mod tests {
         // According to https://docs.rs/tokio-util/0.7.3/tokio_util/codec/index.html#the-encoder-trait
         // the buffer given to the Encoder may already contain data.
         // Therefore, we check whether writing two messages into the same buffer roundtrips correctly.        
-
-
         let mut buf = BytesMut::new();
         let mut codec = MessageCodec::server();
         codec.encode(Message::text("A"), &mut buf).unwrap();

--- a/websocket-codec/src/message.rs
+++ b/websocket-codec/src/message.rs
@@ -467,4 +467,19 @@ mod tests {
             "frame is too long: 18446744069414584575 bytes (ffffffff000000ff)"
         );
     }
+
+    #[test]
+    fn roundtrips_multiple_messages() {
+        // According to https://docs.rs/tokio-util/0.7.3/tokio_util/codec/index.html#the-encoder-trait
+        // the buffer given to the Encoder may already contain data.
+        // Therefore, we check whether writing two messages into the same buffer roundtrips correctly.        
+
+
+        let mut buf = BytesMut::new();
+        let mut codec = MessageCodec::server();
+        codec.encode(Message::text("A"), &mut buf).unwrap();
+        codec.encode(Message::text("B"), &mut buf).unwrap();
+        assert_eq!(codec.decode(&mut buf).unwrap().unwrap(), Message::text("A"));
+        assert_eq!(codec.decode(&mut buf).unwrap().unwrap(), Message::text("B"));
+    }
 }


### PR DESCRIPTION
The current implementation of `MessageCodec` does not correctly handle the buffer when writing.

Specifically, writing multiple websocket messages without flushing between each write will write incorrect frames.

The following does not work on the current implementation:

```
let buf = Vec::new();
let mut framed = FramedWrite::new(buf, websocket_lite::MessageCodec::server());
framed.feed(Message::text("A")).await.unwrap();
framed.feed(Message::text("B")).await.unwrap();
SinkExt::<Message>::flush(&mut framed).await.unwrap();
let test = framed.into_inner();
let framed = FramedRead::new(test.as_slice(), MessageCodec::client());
let read = framed.try_collect::<Vec<_>>().await.unwrap();
assert_eq!(&read, &[Message::text("A"), Message::text("B")]);
```

The reason for this misbehaviour is that the codec implementation assumes that it receives a new buffer for each write. However, according to the [docs](https://docs.rs/tokio-util/0.7.3/tokio_util/codec/index.html#the-encoder-trait):

> The buffer may already contain data, and in this case, the encoder should append the new frame the to buffer rather than overwrite the existing data.

Ignoring this detail, the current implementation overwrites the existing buffer, leading to garbage frames being written.

This PR fixes this bug by correctly handling non-empty buffers in the Encoder implementation.