### PR TITLE
include reason in error message if upgrade fails

### DIFF
--- a/websocket-codec/src/upgrade.rs
+++ b/websocket-codec/src/upgrade.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::result;
 use std::str;
 
@@ -38,7 +39,13 @@ fn validate_server_response(expected_ws_accept: &Sha1Digest, data: &[u8]) -> Res
     let response_len = status.unwrap();
     let code = response.code.unwrap();
     if code != 101 {
-        return Err(format!("server responded with HTTP error {code}", code = code).into());
+        let mut error_message = format!("server responded with HTTP error {code}", code = code);
+
+        if let Some(reason) = response.reason {
+            write!(error_message, ": {:?}", reason).expect("formatting reason failed");
+        }
+
+        return Err(error_message.into());
     }
 
     let ws_accept_header = header(response.headers, "Sec-WebSocket-Accept")?;


### PR DESCRIPTION
When an `Upgrade` fails with a non-`101` status code the server might include a reason message which can help in debugging. In my case I missed a query parameter which was difficult to find out without actually cloning this project locally and annotating the code with `dbg!()` calls. With this change we just add the `reason` to the error message if it's present - debug-printed so there should not be a danger of weird characters sneaking in. This is adding an explicit `Result::expect` call but as far as I can tell this can only happen if the `Debug::fmt` implementation of `&str` fails, hopefully never. Also, an implicit `expect` is already present in each call to `format!` which are used in various other places in the library.