### PR TITLE
Depend only on tokio-util 0.7, not `>=0.6`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,9 +1222,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
 dependencies = [
  "bytes",
  "futures-core",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 [dependencies]
 bytes = "1"
 libfuzzer-sys = "0.4"
-tokio-util = { version=">=0.6", features=["codec"] }
+tokio-util = { version="0.7", features=["codec"] }
 websocket-codec = { path = "../websocket-codec" }
 
 [[bin]]

--- a/hyper-websocket-lite/Cargo.toml
+++ b/hyper-websocket-lite/Cargo.toml
@@ -12,7 +12,7 @@ futures = "0.3"
 hyper = { version = "0.14", features=["http1", "server"] }
 websocket-codec = { version = "0.5", path = "../websocket-codec" }
 tokio = { version = "1", features=["macros"] }
-tokio-util = { version = ">=0.6", features=["codec"] }
+tokio-util = { version = "0.7", features=["codec"] }
 
 [dev-dependencies]
 hyper = { version = "0.14", features=["tcp"] }

--- a/websocket-codec/Cargo.toml
+++ b/websocket-codec/Cargo.toml
@@ -15,7 +15,7 @@ bytes = "1"
 httparse = "1"
 rand = "0.8"
 sha1 = "0.6"
-tokio-util = { version=">=0.6", features=["codec"] }
+tokio-util = { version="0.7", features=["codec"] }
 
 [dev-dependencies]
 assert-allocations = { path="../assert-allocations" }

--- a/websocket-lite/Cargo.toml
+++ b/websocket-lite/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.3"
 native-tls = { version = "0.2", optional = true }
 openssl = { version = "0.10", optional = true }
 rand = "0.8"
-tokio-util = { version = ">=0.6", features = ["codec"] }
+tokio-util = { version = "0.7", features = ["codec"] }
 tokio-openssl = { version = "0.6", optional = true }
 tokio-native-tls = { version = "0.3", optional = true }
 tokio = { version = "1", features = ["net", "io-util"] }


### PR DESCRIPTION
Fixes #300.